### PR TITLE
Production deployment using `docker-compose`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+Dockerfile
+docker-compose.yml
+tests
+README.md
+__pycache__

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,7 @@ Dockerfile
 docker-compose.yml
 tests
 README.md
+.env
+.env.example
+.env.production
 __pycache__

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,4 @@ tests
 README.md
 .env
 .env.example
-.env.production
 __pycache__

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ BOT_USERNAME="<Your bot username>"
 
 HOST=0.0.0.0  # Host the server will listen on
 PORT=5000  # Port the server will listen on
+MODE=PRODUCTION  # =DEBUG for debug mode

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+BOT_TOKEN="<Your token>"
+BOT_USERNAME="<Your bot username>"
+
+HOST=0.0.0.0  # Host the server will listen on
+PORT=5000  # Port the server will listen on

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 __pycache__
+.env.production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.20
+
+RUN apk add python3 poetry
+
+COPY . .
+
+RUN poetry install
+
+CMD ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.20
 RUN apk add python3 poetry
 
 COPY . .
+COPY .env.production .env
 
 RUN poetry install
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ giver then in the chat with the bot, run the `/start` command.
 
 ## Use the server
 
+Simply run `./run.sh`, to run the server and the telegram listener separatly,
+refer to the next two sections.
+
 ### Start the chat id giver
 
 Run this listen server for the bot to give to each user in private message

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ giver then in the chat with the bot, run the `/start` command.
 
 ## Use the server
 
+### With docker compose
+
+Run `docker-compose up`, or `docker compose up`, to run the bot using docker.
+
+### Without docker compose
+
 Simply run `./run.sh`, to run the server and the telegram listener separatly,
 refer to the next two sections.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Converter
 
-## Install dependencies
+This project includes a web server offering an interface to write markdown 
+message which is then sent to the user with a telegram bot with the right
+formatting.
 
-```sh
-poetry install
-```
+## Installation
 
-Add the token and the username of the sender bot in the `./.env` file. The
+### Setup the .env 
+
+Use the file `/.env.example` to get started, and follow the next instruction to
+setup the bot.
+
+Add the token and the username of the sender bot in the `/.env` file. The
 username is for displaying purpose.
 In CLI mode, also add your chat id where the bot has to send messages in this
 file.
@@ -17,6 +22,9 @@ BOT_USERNAME="@YourBotUsername"
 
 # Optional
 CHAT_ID="your_chat_id"
+HOST=0.0.0.0  # Host the server will listen on
+PORT=5000  # Port the server will listen on
+MODE=PRODUCTION  # =DEBUG for debug mode
 ```
 
 ### How to get these credentials
@@ -24,18 +32,33 @@ CHAT_ID="your_chat_id"
 For the bot token, talk to @FatherBot. For the chat id, you can run the chat id
 giver then in the chat with the bot, run the `/start` command.
 
-## Use the server
+## How to run the bot
+
+You can run the bot using `docker compose` or by running the `run.sh` script
 
 ### With docker compose
+
+Create a file `.env.production`, and setup it as described above 
 
 Run `docker-compose up`, or `docker compose up`, to run the bot using docker.
 
 ### Without docker compose
 
+#### Install dependencies
+
+Run the following command at the root of the repository :
+
+```
+poetry install
+```
+
+#### Run the project
+
 Simply run `./run.sh`, to run the server and the telegram listener separatly,
 refer to the next two sections.
 
-### Start the chat id giver
+
+#### Run the chat id giver only
 
 Run this listen server for the bot to give to each user in private message
 their chat id when they run the command `/start` in this channel.
@@ -46,7 +69,7 @@ poetry shell
 python listenChatId.py
 ```
 
-### Start the well-formatted message sender
+#### Run the well-formatted message sender only
 
 Run in another process this Flask server, which will be listened by default on `http://127.0.0.1:5000`
 
@@ -56,9 +79,9 @@ poetry shell
 python main.py
 ```
 
-### Endpoints
+## API documentation
 
-#### `POST` `/send`
+### `POST` `/send`
 
 Requires the `"Content-Type": "application/json"` header with a json body with
 the following structure
@@ -83,14 +106,14 @@ or
 
 Send the given message in the channel with the set up chat id.
 
-#### `GET` `/`
+### `GET` `/`
 
 Render a frontend interface to input the markdown, render it in HTML and then
 send the message as in the previewed html.
 
 ### About the format
 
-#### Markdown
+### Markdown
 
 The markdown is strict. Then, the syntax here is supported
 
@@ -135,7 +158,7 @@ This is `inline code`
 1. Actual numbers don't matter, just that it's a number
 ```
 
-#### HTML
+### HTML
 
 Use `<span class="spoiler"/></span>` for the spoiler.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  bot:
+    build: .
+    ports:
+      - "8000:5000"

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from eirb_com_helper.server import app
 
 HOST = getenv("HOST", "0.0.0.0")
 PORT = int(getenv("PORT", 5000))
+IS_DEBUG = getenv("MODE", "PRODUCTION") == "DEBUG"
 
 if __name__ == "__main__":
-    app.run(debug=True, host=HOST, port=PORT)
+    app.run(debug=IS_DEBUG, host=HOST, port=PORT)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,11 @@
+from os import getenv
 from dotenv_vault import load_dotenv
 load_dotenv()
 
 from eirb_com_helper.server import app 
 
+HOST = getenv("HOST", "0.0.0.0")
+PORT = int(getenv("PORT", 5000))
+
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=True, host=HOST, port=PORT)

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+poetry run python main.py &
+poetry run python listenChatId.py


### PR DESCRIPTION
Added support for `docker-compose` for production deployment. To do so, I created a script `run.sh` that runs the server and the chat listener using `poetry`.

TODO: 
* ~~remove debug in production mode~~
* ~~take care of `WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.`~~ (is deployment dependent, not docker depnedent)